### PR TITLE
Fix MacVim build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           wget --method=GET \
           --quiet --content-on-error \
           --output-document=- \
-          --header 'Authorization: Bearer ${{ secrets.PERSONAL_GITHUB_TOKEN }}' \
+          --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
           --header 'Content-Type: application/json' \
           'https://api.github.com/rate_limit'
 
@@ -139,7 +139,6 @@ jobs:
           gui: '${{ matrix.gui }}'
           download: '${{ matrix.download }}'
           cache: 'test'
-          github_token: '${{ secrets.PERSONAL_GITHUB_TOKEN }}'
       - name: 'Check Vim version'
         uses: './actions/check-version'
         with:
@@ -161,7 +160,6 @@ jobs:
           vim_type: '${{ matrix.vim_type }}'
           gui: '${{ matrix.gui }}'
           download: '${{ matrix.download }}'
-          github_token: '${{ secrets.PERSONAL_GITHUB_TOKEN }}'
       - name: 'Check Setup Vim is done with cache'
         if: "matrix.download == 'never'"
         run: |
@@ -206,28 +204,24 @@ jobs:
         with:
           vim_version: 'head'
           vim_type: 'Vim'
-          github_token: '${{ secrets.PERSONAL_GITHUB_TOKEN }}'
       - name: 'Setup Vim latest'
         id: 'vim_latest'
         uses: './actions/setup-vim'
         with:
           vim_version: 'v8.2.0000'
           vim_type: 'Vim'
-          github_token: '${{ secrets.PERSONAL_GITHUB_TOKEN }}'
       - name: 'Setup Neovim head'
         id: 'neovim_head'
         uses: './actions/setup-vim'
         with:
           vim_version: 'head'
           vim_type: 'Neovim'
-          github_token: '${{ secrets.PERSONAL_GITHUB_TOKEN }}'
       - name: 'Setup Neovim latest'
         id: 'neovim_latest'
         uses: './actions/setup-vim'
         with:
           vim_version: 'v0.5.0'
           vim_type: 'Neovim'
-          github_token: '${{ secrets.PERSONAL_GITHUB_TOKEN }}'
       - name: 'Setup MacVim head'
         if: "matrix.platform == 'MacOS'"
         id: 'macvim_head'
@@ -235,7 +229,6 @@ jobs:
         with:
           vim_version: 'head'
           vim_type: 'MacVim'
-          github_token: '${{ secrets.PERSONAL_GITHUB_TOKEN }}'
       - name: 'Setup MacVim latest'
         if: "matrix.platform == 'MacOS'"
         id: 'macvim_latest'
@@ -243,7 +236,6 @@ jobs:
         with:
           vim_version: 'snapshot-162'
           vim_type: 'MacVim'
-          github_token: '${{ secrets.PERSONAL_GITHUB_TOKEN }}'
 
       - name: 'Check Vim head version'
         if: "always() && steps.vim_head.conclusion == 'success'"
@@ -313,6 +305,6 @@ jobs:
           wget --method=GET \
           --quiet --content-on-error \
           --output-document=- \
-          --header 'Authorization: Bearer ${{ secrets.PERSONAL_GITHUB_TOKEN }}' \
+          --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
           --header 'Content-Type: application/json' \
           'https://api.github.com/rate_limit'

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,14 +42,6 @@ async function main(): Promise<void> {
   let cacheHit: string | undefined;
 
   if (!installed) {
-    if (process.platform === "darwin") {
-      // Workaround:
-      // Building Vim before v8.2.1119 on MacOS will fail because default Xcode was changed to 12.
-      // https://github.com/actions/virtual-environments/commit/c09dca28df69d9aaaeac5635257d23722810d307#diff-7a1606bd717fc0cf55f9419157117d9ca306f91bd2fdfc294720687d7be1b2c7R220
-      // We change using version of Xcode to 11 to build old Vim.
-      process.env["DEVELOPER_DIR"] = "/Applications/Xcode_11.7.app/Contents/Developer";
-    }
-
     await io.mkdirP(installPath);
 
     const cacheInput = core.getInput("cache");

--- a/src/installer/macvim_build_installer.ts
+++ b/src/installer/macvim_build_installer.ts
@@ -4,6 +4,9 @@ import * as io from "@actions/io";
 import {BuildInstaller} from "./build_installer";
 import {execGit, gitClone} from "../commands";
 import {FixedVersion} from "../interfaces";
+import {backportPatch} from "../patch";
+import {Buffer} from "buffer";
+import * as semver from "semver";
 
 export class MacVimBuildInstaller extends BuildInstaller {
   readonly repository = "macvim-dev/macvim";
@@ -14,8 +17,8 @@ export class MacVimBuildInstaller extends BuildInstaller {
   }
 
   async obtainFixedVersion(vimVersion: string): Promise<string> {
-    const log = await execGit(["log", "-1", "--format=format:%B"], {cwd: this.repositoryPath(vimVersion)});
-    const matched = /Vim\s+patch\s+v?(\d+\.\d+\.\d+)/.exec(log);
+    const log = await execGit(["log", "-20", "--format=format:%s"], {cwd: this.repositoryPath(vimVersion)});
+    const matched = /^\s*patch\s+v?(\d+\.\d+\.\d+)/m.exec(log);
     if (matched) {
       const version = `v${matched[1]}`;
       const tag = await super.obtainFixedVersion(vimVersion);
@@ -26,18 +29,42 @@ export class MacVimBuildInstaller extends BuildInstaller {
   }
 
   async install(vimVersion: FixedVersion): Promise<void> {
+    await exec("xcode-select", ["-p"]);
     const tag = this.tags[vimVersion] || vimVersion;
     const reposPath = this.repositoryPath(vimVersion);
     await gitClone("macvim-dev/macvim", tag, reposPath);
-    const srcPath = path.join(reposPath, "src");
-    await exec("./configure", [], {cwd: srcPath});
+    await backportPatch(reposPath, vimVersion);
 
-    // To avoid `sed: RE error: illegal byte sequence` error.
-    await exec("sed", ["-i", "", "s/\\tsed/LC_CTYPE=C sed/", "po/Makefile"], {cwd: srcPath});
+    // To avoid `sed: RE error: illegal byte sequence` error, should set 'LC_CTYPE=C'.
+    process.env.LC_CTYPE = "C";
 
-    await exec("make", [], {cwd: srcPath});
+    const args: string[] = [];
+    if (semver.lte(vimVersion, "8.2.2127", true)) {
+      // Build only x86_64 arch since Sparkle.framework < 1.24.0 doesn't support Apple Silicon.
+      if (semver.lte(vimVersion, "8.2.2013", true)) {
+        args.push("--with-macarchs=x86_64");
+      }
+
+      // Fix broken "--with-macarchs" flag.
+      const patch = `
+--- a/src/auto/configure
++++ b/src/auto/configure
+@@ -4758,7 +4758,7 @@ fi
+ $as_echo_n "checking if architectures are supported... " >&6; }
+     save_cflags="$CFLAGS"
+     save_ldflags="$LDFLAGS"
+-    archflags=\`echo "$ARCHS" | sed -e 's/[[:<:]]/-arch /g'\`
++    archflags=\`echo "$ARCHS" | sed 's/[[:>:]][ ][ ]*[[:<:]]/ -arch /g' | sed 's/^/-arch /g'\`
+     CFLAGS="$CFLAGS $archflags"
+     LDFLAGS="$LDFLAGS $archflags"
+     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+      `.trim() + "\n";
+      await exec("patch", ["-p1"], {cwd: reposPath, input: Buffer.from(patch)});
+    }
+    await exec("./configure", args, {cwd: reposPath});
+    await exec("make", [], {cwd: reposPath});
     await io.mkdirP(this.installDir);
-    await io.cp(path.join(srcPath, "MacVim", "build", "Release", "MacVim.app"), this.installDir, {recursive: true});
+    await io.cp(path.join(reposPath, "src", "MacVim", "build", "Release", "MacVim.app"), this.installDir, {recursive: true});
   }
 
   getPath(): string {

--- a/src/installer/macvim_releases_installer.ts
+++ b/src/installer/macvim_releases_installer.ts
@@ -17,7 +17,7 @@ function checkPath(targetPath: string): boolean {
 export class MacVimReleasesInstaller extends ReleasesInstaller {
   readonly repository: string = "macvim-dev/macvim";
   readonly assetNamePatterns: RegExp[] = [/^MacVim.*\.dmg$/];
-  readonly vimVersionPattern: RegExp = /[vV]im\s+patch.*(\d+\.\d+\.\d+)/;
+  readonly vimVersionPattern: RegExp = /(Vim\s+patch|Updated\s+to\s+Vim)\s*(\d+\.\d+\.\d+)/i;
 
   toSemverString(release: Release): string {
     const matched = this.vimVersionPattern.exec(release.body ?? "");

--- a/src/installer/unix_vim_build_installer.ts
+++ b/src/installer/unix_vim_build_installer.ts
@@ -2,10 +2,18 @@ import * as path from "path";
 import {exec} from "@actions/exec";
 import {FixedVersion, Installer} from "../interfaces";
 import {VimBuildInstaller} from "./vim_build_installer";
+import {backportPatch} from "../patch";
 
 export class UnixVimBuildInstaller extends VimBuildInstaller implements Installer {
   async install(vimVersion: FixedVersion): Promise<void> {
     const reposPath = await this.cloneVim(vimVersion);
+    await backportPatch(reposPath, vimVersion);
+
+    if (process.platform === "darwin") {
+      // To avoid `sed: RE error: illegal byte sequence` error, should set 'LC_CTYPE=C'.
+      process.env.LC_CTYPE = "C";
+    }
+
     const args = [`--prefix=${this.installDir}`, "--with-features=huge"];
     if (this.isGUI) {
       await exec("sudo", ["apt-get", "update"]);

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -1,0 +1,34 @@
+import * as semver from "semver";
+import {Buffer} from "buffer";
+import {exec} from "@actions/exec";
+
+export async function backportPatch(reposPath: string, vimVersion: string): Promise<void> {
+  const vimSemver = semver.coerce(vimVersion, {loose: true});
+  if (!vimSemver) {
+    return;
+  }
+
+  if (semver.lt(vimSemver, "8.2.1119")) {
+    // Workaround:
+    // Building Vim before v8.2.1119 on MacOS will fail because default Xcode was changed to 12.
+    // https://github.com/actions/virtual-environments/commit/c09dca28df69d9aaaeac5635257d23722810d307#diff-7a1606bd717fc0cf55f9419157117d9ca306f91bd2fdfc294720687d7be1b2c7R220
+    //
+    // We should apply patch v8.2.1119 to src/auto/configure.
+    const patch = `
+--- a/src/auto/configure
++++ b/src/auto/configure
+@@ -14143,8 +14143,8 @@ else
+ main() {
+   uint32_t nr1 = (uint32_t)-1;
+   uint32_t nr2 = (uint32_t)0xffffffffUL;
+-  if (sizeof(uint32_t) != 4 || nr1 != 0xffffffffUL || nr2 + 1 != 0) exit(1);
+-  exit(0);
++  if (sizeof(uint32_t) != 4 || nr1 != 0xffffffffUL || nr2 + 1 != 0) return 1;
++  return 0;
+ }
+ _ACEOF
+ if ac_fn_c_try_run "$LINENO"; then :
+    `.trim() + "\n";
+    await exec("patch", ["-p1"], {cwd: reposPath, input: Buffer.from(patch)});
+  }
+}


### PR DESCRIPTION
### Fix MacVim build

* デフォルトのXcode (13.1) を使えるように、v8.2.1119 の `src/auto/configure` への変更を backport
* `MacVimBuildInstaller.obtainFixedVersion()` が正しく機能するように `git log` の範囲と正規表現パターンを修正
* snapshot-167 未満のとき内蔵の Sparkle.framework が arm64 に対応してないため、x86_64 のみビルドするよう configure オプションに `--with-macarchs=x86_64` を追加

### Fix version pattern in MacVim release

* 新しめのリリースだと `Updated to Vim x.x.xxxx` のフォーマットになっているので、これに対応

### Fix CI `GUI/BD: Vim head on linux`

Check Vim version が timeout する。
https://github.com/thinca/action-setup-vim/runs/4693095117

v8.2.3721 での変更により、以下のバージョン取得処理で `0put a` がエラーを出すようになり、 `wq!` が実行されず gvim が終了しないため。

```vim
redir! @a
version
0put a
wq!
```

`redir! > file` の方式に変更した。 