### PR TITLE
Use GraphQL API instead of REST API to fetch releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,27 +16,36 @@ jobs:
         run: |
           npm ci
           npm run --silent build -- --mode=production
-          mkdir -p ${GITHUB_WORKSPACE}/actions/setup-vim
-          cp action.js action.yml ${GITHUB_WORKSPACE}/actions/setup-vim
+          mkdir -p ${{ github.workspace }}/actions/setup-vim
+          cp action.js action.yml ${{ github.workspace }}/actions/setup-vim
 
-          cd ${GITHUB_WORKSPACE}/.github/actions/check-version
+          cd ${{ github.workspace }}/.github/actions/check-version
           npm ci
           npm run --silent build
-          mkdir -p ${GITHUB_WORKSPACE}/actions/check-version
-          cp action.js action.yml ${GITHUB_WORKSPACE}/actions/check-version
+          mkdir -p ${{ github.workspace }}/actions/check-version
+          cp action.js action.yml ${{ github.workspace }}/actions/check-version
       - name: 'Upload actions as artifact'
         uses: 'actions/upload-artifact@v2'
         with:
           name: 'actions'
           path: 'actions'
-      - name: 'Show GitHub API rate limit'
-        run: |
-          wget --method=GET \
-          --quiet --content-on-error \
-          --output-document=- \
-          --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-          --header 'Content-Type: application/json' \
-          'https://api.github.com/rate_limit'
+      - name: 'Get GitHub GraphQL API rate limit'
+        id: rate_limit
+        uses: octokit/graphql-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          query: |
+            query {
+              rateLimit {
+                limit
+                cost
+                remaining
+                resetAt
+              }
+            }
+      - name: 'Show GitHub GraphQL API rate limit'
+        run: echo "${{ steps.rate_limit.outputs.data }}"
 
   test:
     name: '${{ matrix.gui_cui }}/${{ matrix.dl_bd }}: ${{ matrix.vim_type }} ${{ matrix.vim_version }} on ${{ matrix.platform }}'
@@ -300,11 +309,20 @@ jobs:
     timeout-minutes: 1
     if: 'always()'
     steps:
-      - name: 'Show GitHub API rate limit'
-        run: |
-          wget --method=GET \
-          --quiet --content-on-error \
-          --output-document=- \
-          --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-          --header 'Content-Type: application/json' \
-          'https://api.github.com/rate_limit'
+      - name: 'Get GitHub GraphQL API rate limit'
+        id: rate_limit
+        uses: octokit/graphql-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          query: |
+            query {
+              rateLimit {
+                limit
+                cost
+                remaining
+                resetAt
+              }
+            }
+      - name: 'Show GitHub GraphQL API rate limit'
+        run: echo "${{ steps.rate_limit.outputs.data }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@actions/exec": "^1.1.0",
         "@actions/io": "^1.1.1",
         "@actions/tool-cache": "^1.7.1",
-        "@octokit/rest": "^18.9.0",
+        "@octokit/graphql": "^4.8.0",
         "semver": "^7.3.5"
       },
       "devDependencies": {
@@ -450,28 +450,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@octokit/auth-token": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
-      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
-      "dependencies": {
-        "@octokit/types": "^6.0.3"
-      }
-    },
-    "node_modules/@octokit/core": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
-      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
-      "dependencies": {
-        "@octokit/auth-token": "^2.4.4",
-        "@octokit/graphql": "^4.5.8",
-        "@octokit/request": "^5.6.0",
-        "@octokit/request-error": "^2.0.5",
-        "@octokit/types": "^6.0.3",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
-      }
-    },
     "node_modules/@octokit/endpoint": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
@@ -483,11 +461,11 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.1.tgz",
-      "integrity": "sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
       "dependencies": {
-        "@octokit/request": "^5.3.0",
+        "@octokit/request": "^5.6.0",
         "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
       }
@@ -496,37 +474,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.7.0.tgz",
       "integrity": "sha512-TUJ16DJU8mekne6+KVcMV5g6g/rJlrnIKn7aALG9QrNpnEipFc1xjoarh0PKaAWf2Hf+HwthRKYt+9mCm5RsRg=="
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz",
-      "integrity": "sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==",
-      "dependencies": {
-        "@octokit/types": "^6.11.0"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=2"
-      }
-    },
-    "node_modules/@octokit/plugin-request-log": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
-      "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.7.0.tgz",
-      "integrity": "sha512-G7sgccWRYQMwcHJXkDY/sDxbXeKiZkFQqUtzBCwmrzCNj2GQf3VygQ4T/BFL2crLVpIbenkE/c0ErhYOte2MPw==",
-      "dependencies": {
-        "@octokit/types": "^6.24.0",
-        "deprecation": "^2.3.1"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
     },
     "node_modules/@octokit/request": {
       "version": "5.6.0",
@@ -549,17 +496,6 @@
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/@octokit/rest": {
-      "version": "18.9.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.9.0.tgz",
-      "integrity": "sha512-VrmrE8gjpuOoDAGjrQq2j9ZhOE6LxaqxaQg0yMrrEnnQZy2ZcAnr5qbVfKsMF0up/48PRV/VFS/2GSMhA7nTdA==",
-      "dependencies": {
-        "@octokit/core": "^3.5.0",
-        "@octokit/plugin-paginate-rest": "^2.6.2",
-        "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.7.0"
       }
     },
     "node_modules/@octokit/types": {
@@ -1181,11 +1117,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "node_modules/before-after-hook": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.1.tgz",
-      "integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4633,28 +4564,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@octokit/auth-token": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
-      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
-      "requires": {
-        "@octokit/types": "^6.0.3"
-      }
-    },
-    "@octokit/core": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
-      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
-      "requires": {
-        "@octokit/auth-token": "^2.4.4",
-        "@octokit/graphql": "^4.5.8",
-        "@octokit/request": "^5.6.0",
-        "@octokit/request-error": "^2.0.5",
-        "@octokit/types": "^6.0.3",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
-      }
-    },
     "@octokit/endpoint": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
@@ -4666,11 +4575,11 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.1.tgz",
-      "integrity": "sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
       "requires": {
-        "@octokit/request": "^5.3.0",
+        "@octokit/request": "^5.6.0",
         "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
       }
@@ -4679,29 +4588,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.7.0.tgz",
       "integrity": "sha512-TUJ16DJU8mekne6+KVcMV5g6g/rJlrnIKn7aALG9QrNpnEipFc1xjoarh0PKaAWf2Hf+HwthRKYt+9mCm5RsRg=="
-    },
-    "@octokit/plugin-paginate-rest": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz",
-      "integrity": "sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==",
-      "requires": {
-        "@octokit/types": "^6.11.0"
-      }
-    },
-    "@octokit/plugin-request-log": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
-      "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
-      "requires": {}
-    },
-    "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.7.0.tgz",
-      "integrity": "sha512-G7sgccWRYQMwcHJXkDY/sDxbXeKiZkFQqUtzBCwmrzCNj2GQf3VygQ4T/BFL2crLVpIbenkE/c0ErhYOte2MPw==",
-      "requires": {
-        "@octokit/types": "^6.24.0",
-        "deprecation": "^2.3.1"
-      }
     },
     "@octokit/request": {
       "version": "5.6.0",
@@ -4724,17 +4610,6 @@
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
-      }
-    },
-    "@octokit/rest": {
-      "version": "18.9.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.9.0.tgz",
-      "integrity": "sha512-VrmrE8gjpuOoDAGjrQq2j9ZhOE6LxaqxaQg0yMrrEnnQZy2ZcAnr5qbVfKsMF0up/48PRV/VFS/2GSMhA7nTdA==",
-      "requires": {
-        "@octokit/core": "^3.5.0",
-        "@octokit/plugin-paginate-rest": "^2.6.2",
-        "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.7.0"
       }
     },
     "@octokit/types": {
@@ -5230,11 +5105,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "before-after-hook": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.1.tgz",
-      "integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@actions/exec": "^1.1.0",
     "@actions/io": "^1.1.1",
     "@actions/tool-cache": "^1.7.1",
-    "@octokit/rest": "^18.9.0",
+    "@octokit/graphql": "^4.8.0",
     "semver": "^7.3.5"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
   try {
     const stat = fs.statSync(installPath);
     installed = stat.isDirectory();
-  } catch (e) {
+  } catch (_e) {
     // path not exist
   }
 

--- a/src/installer/linux_neovim_build_installer.ts
+++ b/src/installer/linux_neovim_build_installer.ts
@@ -41,7 +41,7 @@ export class LinuxNeovimBuildInstaller extends NeovimBuildInstaller {
     try {
       const content = readFileSync(filepath, {encoding: "utf8"});
       return 0 <= content.indexOf(target);
-    } catch (e) {
+    } catch (_e) {
       return false;
     }
   }

--- a/src/installer/linux_vim_releases_installer.ts
+++ b/src/installer/linux_vim_releases_installer.ts
@@ -1,23 +1,16 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as io from "@actions/io";
-import {toSemver} from "./releases_installer";
 import {SemverReleasesInstaller} from "./semver_releases_installer";
 import {FixedVersion} from "../interfaces";
-
-const AVAILABLE_VERSION = toSemver("v8.1.1239");
 
 export class LinuxVimReleasesInstaller extends SemverReleasesInstaller {
   readonly repository: string = "vim/vim-appimage";
   readonly assetNamePatterns: RegExp[] = [/\.AppImage$/];
+  readonly availableVersion: string = "v8.1.1239";
 
   getExecutableName(): string {
     return this.isGUI ? "gvim" : "vim";
-  }
-
-  canInstall(version: string): boolean {
-    const ver = toSemver(version);
-    return ver == null || AVAILABLE_VERSION == null || 0 <= ver.compare(AVAILABLE_VERSION);
   }
 
   async install(vimVersion: FixedVersion): Promise<void> {

--- a/src/installer/macvim_releases_installer.ts
+++ b/src/installer/macvim_releases_installer.ts
@@ -17,7 +17,7 @@ function checkPath(targetPath: string): boolean {
 export class MacVimReleasesInstaller extends ReleasesInstaller {
   readonly repository: string = "macvim-dev/macvim";
   readonly assetNamePatterns: RegExp[] = [/^MacVim.*\.dmg$/];
-  readonly vimVersionPattern: RegExp = /(Vim\s+patch|Updated\s+to\s+Vim)\s*(\d+\.\d+\.\d+)/i;
+  readonly vimVersionPattern: RegExp = /(?:Vim\s+patch|Updated\s+to\s+Vim)\s*(\d+\.\d+\.\d+)/i;
 
   toSemverString(release: Release): string {
     const matched = this.vimVersionPattern.exec(release.body ?? "");

--- a/src/installer/macvim_releases_installer.ts
+++ b/src/installer/macvim_releases_installer.ts
@@ -9,7 +9,7 @@ function checkPath(targetPath: string): boolean {
   try {
     const stat = fs.statSync(targetPath);
     return stat.isFile() || stat.isDirectory();
-  } catch (e) {
+  } catch (_e) {
     return false;
   }
 }
@@ -20,7 +20,7 @@ export class MacVimReleasesInstaller extends ReleasesInstaller {
   readonly vimVersionPattern: RegExp = /(?:Vim\s+patch|Updated\s+to\s+Vim)\s*(\d+\.\d+\.\d+)/i;
 
   toSemverString(release: Release): string {
-    const matched = this.vimVersionPattern.exec(release.body ?? "");
+    const matched = this.vimVersionPattern.exec(release.description ?? "");
     return matched?.[1] || "";
   }
 

--- a/src/installer/semver_releases_installer.ts
+++ b/src/installer/semver_releases_installer.ts
@@ -1,7 +1,13 @@
-import {ReleasesInstaller, Release} from "./releases_installer";
+import {ReleasesInstaller, Release, toSemver} from "./releases_installer";
 
 export abstract class SemverReleasesInstaller extends ReleasesInstaller {
   toSemverString(release: Release): string {
-    return release.tag_name;
+    return release.tagName;
+  }
+
+  canInstall(version: string): boolean {
+    const ver = toSemver(version);
+    const avail = toSemver(this.availableVersion);
+    return !ver || !avail || ver.compare(avail) >= 0;
   }
 }

--- a/src/installer/windows_vim_releases_installer.ts
+++ b/src/installer/windows_vim_releases_installer.ts
@@ -9,6 +9,7 @@ import {TEMP_PATH} from "../temp";
 export class WindowsVimReleasesInstaller extends SemverReleasesInstaller {
   readonly repository: string = "vim/vim-win32-installer";
   readonly assetNamePatterns: RegExp[] = [/^gvim_.*_x64(?:_signed)?\.zip$/];
+  readonly availableVersion: string = "v8.0.0";
 
   getExecutableName(): string {
     return this.isGUI ? "gvim" : "vim";


### PR DESCRIPTION
### GraphQL

releases 取得に使っている REST API を GraphQL API に置き換えました。

REST API では、指定バージョンが semver 形式でない場合に `perpetuateVersion()` で getRef や getTag を何度か呼ぶ必要がありますが、GraphQL API では `fetchReleases()` で release の tagCommit 情報もまとめて取ることができ、API 呼び出しコストを減らせます。

また、ReleasesInstaller で availableVersion が指定されているもの (LinuxVimReleasesInstaller など) は、releases を全部取得するのではなく availableVersion に到達したら取得を打ち切るようにして、必要以上の API 呼び出しをやめています。
ついでに WindowsVimReleasesInstaller も availableVersion を v8.0.0 としました。

キャッシュなしの状態で CI を回した場合のコスト消費は 500 以下になり、改善していると思います。

### Neovim の releases キャッシュ問題

`fetchReleases()` では、新規取得したリリースタグがキャッシュ内にあればそこで取得をやめていましたが、Neovim は nightly タグが随時更新されているため、キャッシュが更新されない状態になっていたと思われます。

```
cache: [nightly, v0.5.1, stable. v0.5.0, ...]
new fetch: [nightly, v0.6.0, stable, v0.5.1, v0.5.0, ...]

=> new fetch の先頭が nightly で、cache にも nightly があるので、ここで releases 更新終了
=> v0.6.0 が releases に追加されないため、インストールに v0.6.0 を指定すると releases にないというエラーになる
```

タグの commit.oid の一致も確認するように修正しました。