### PR TITLE
MacOS: Set `LC_ALL=C` rather than `LC_CTYPE=C`

### DIFF
--- a/src/installer/macvim_build_installer.ts
+++ b/src/installer/macvim_build_installer.ts
@@ -35,8 +35,8 @@ export class MacVimBuildInstaller extends BuildInstaller {
     await gitClone("macvim-dev/macvim", tag, reposPath);
     await backportPatch(reposPath, vimVersion);
 
-    // To avoid `sed: RE error: illegal byte sequence` error, should set 'LC_CTYPE=C'.
-    process.env.LC_CTYPE = "C";
+    // To avoid `sed: RE error: illegal byte sequence` error, should set 'LC_ALL=C'.
+    process.env.LC_ALL = "C";
 
     const args: string[] = [];
     if (semver.lte(vimVersion, "8.2.2127", true)) {

--- a/src/installer/unix_vim_build_installer.ts
+++ b/src/installer/unix_vim_build_installer.ts
@@ -10,8 +10,8 @@ export class UnixVimBuildInstaller extends VimBuildInstaller implements Installe
     await backportPatch(reposPath, vimVersion);
 
     if (process.platform === "darwin") {
-      // To avoid `sed: RE error: illegal byte sequence` error, should set 'LC_CTYPE=C'.
-      process.env.LC_CTYPE = "C";
+      // To avoid `sed: RE error: illegal byte sequence` error, should set 'LC_ALL=C'.
+      process.env.LC_ALL = "C";
     }
 
     const args = [`--prefix=${this.installDir}`, "--with-features=huge"];


### PR DESCRIPTION
`LC_ALL` has been set to `en_US.UTF-8` and it overrides all of `LC_*`, thus we should set `LC_ALL=C` rather than `LC_CTYPE=C`.
