### PR TITLE
Add `arch` argument for Windows

### DIFF
--- a/.github/actions/check-version/action.yml
+++ b/.github/actions/check-version/action.yml
@@ -17,6 +17,12 @@ inputs:
       When this is `yes`, setups the GUI version.
       And `outputs.executable` points to GUI version of Vim.
     required: false
+  arch:
+    description: |-
+      Architecture of Vim.
+      This is either of `x86_64` or `x86`, enable when `vim_type` is `vim` on Windows.
+    required: false
+    default: 'x86_64'
   executable:
     description: |-
       The name of executable file.

--- a/.github/actions/check-version/src/index.ts
+++ b/.github/actions/check-version/src/index.ts
@@ -147,6 +147,14 @@ async function check(): Promise<string> {
   core.info(versionOutput);
   core.info("-------");
 
+  if (process.platform === "win32" && vimType === "vim") {
+    const actualArch = /(32|64)-bit/.exec(versionOutput)?.[0];
+    const expectedArch = core.getInput("arch").includes("64") ? "64-bit" : "32-bit";
+    if (expectedArch !== actualArch) {
+      throw Error(`Installed Vim's architecture is wrong:\nexpected: ${expectedArch}\nactual: ${actualArch}`);
+    }
+  }
+
   const normalizedExpectedVersion = normalizeVersion(expectedVimVersion);
 
   if (actualVersion === "nightly") {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
         platform: ['Linux', 'MacOS', 'Windows']
         gui_cui: ['GUI', 'CUI']
         dl_bd: ['DL', 'AT', 'BD']
+        arch: ['x86_64', 'x86']
 
         include:
           - platform: 'Linux'
@@ -128,6 +129,24 @@ jobs:
             platform: 'Linux'
           - vim_type: 'MacVim'
             platform: 'Windows'
+          # arch=x86 is only for Windows GUI head
+          - vim_type: 'Neovim'
+            arch: 'x86'
+          - vim_type: 'MacVim'
+            arch: 'x86'
+          - vim_version: 'latest'
+            arch: 'x86'
+          - vim_version: 'stable'
+            arch: 'x86'
+          - platform: 'Linux'
+            arch: 'x86'
+          - platform: 'MacOS'
+            arch: 'x86'
+          - gui_cui: 'CUI'
+            arch: 'x86'
+          - dl_bd: 'AT'
+            arch: 'x86'
+
       fail-fast: false
 
     needs: 'setup-actions'
@@ -150,6 +169,7 @@ jobs:
           vim_version: '${{ matrix.version || matrix.vim_version }}'
           vim_type: '${{ matrix.vim_type }}'
           gui: '${{ matrix.gui }}'
+          arch: '${{ matrix.arch }}'
           download: '${{ matrix.download }}'
           cache: 'test'
       - name: 'Check Vim version'
@@ -160,6 +180,7 @@ jobs:
           executable_path: '${{ steps.vim.outputs.executable_path }}'
           vim_type: '${{ matrix.vim_type }}'
           gui: '${{ matrix.gui }}'
+          arch: '${{ matrix.arch }}'
       - name: 'Delete installed Vim to reinstall'
         if: "matrix.download == 'never'"
         run: |

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,12 @@ inputs:
       And `outputs.executable` points to GUI version of Vim.
     required: false
     default: 'no'
+  arch:
+    description: |-
+      Architecture of Vim.
+      This is either of `x86_64` or `x86`, enable when `vim_type` is `vim` on Windows.
+    required: false
+    default: 'x86_64'
   download:
     description: |-
       When this is `always`, downloads the officially released binary, or fail if unavailable.

--- a/src/installer/windows_vim_build_installer.ts
+++ b/src/installer/windows_vim_build_installer.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import * as core from "@actions/core";
 import {exec} from "@actions/exec";
 import * as io from "@actions/io";
 import {FixedVersion} from "../interfaces";
@@ -8,13 +9,14 @@ import {VimBuildInstaller} from "./vim_build_installer";
 export class WindowsVimBuildInstaller extends VimBuildInstaller {
   async install(vimVersion: FixedVersion): Promise<void> {
     const reposPath = await this.cloneVim(vimVersion);
+    const arch = core.getInput("arch").includes("64") ? "x64" : "x86";
     const srcPath = path.join(reposPath, "src");
     const batPath = path.join(srcPath, "install.bat");
     const guiOptions = this.isGUI ? "GUI=yes OLE=yes DIRECTX=yes" : "GUI=no OLE=no DIRECTX=no";
     const vsPath = await this.getVSPath();
 
     fs.writeFileSync(batPath, `
-    call "${path.join(vsPath, "VC\\Auxiliary\\Build\\vcvarsall.bat")}" x64
+    call "${path.join(vsPath, "VC\\Auxiliary\\Build\\vcvarsall.bat")}" ${arch}
 
     rem Suppress progress animation
     sed -e "s/@<<$/@<< | sed -e 's#.*\\\\r.*##'/" Make_mvc.mak > Make_mvc2.mak

--- a/src/installer/windows_vim_releases_installer.ts
+++ b/src/installer/windows_vim_releases_installer.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import * as core from "@actions/core";
 import {extractZip} from "@actions/tool-cache";
 import {SemverReleasesInstaller} from "./semver_releases_installer";
 import {ActionError} from "../action_error";
@@ -8,7 +9,8 @@ import {TEMP_PATH} from "../temp";
 
 export class WindowsVimReleasesInstaller extends SemverReleasesInstaller {
   readonly repository: string = "vim/vim-win32-installer";
-  readonly assetNamePatterns: RegExp[] = [/^gvim_.*_x64(?:_signed)?\.zip$/];
+  readonly arch = core.getInput("arch").includes("64") ? "x64" : "x86";
+  readonly assetNamePatterns: RegExp[] = [RegExp(String.raw`^gvim_.*_${this.arch}(?:_signed)?\.zip$`)];
   readonly availableVersion: string = "v8.0.0";
 
   getExecutableName(): string {


### PR DESCRIPTION
Enable to download/build 32bit Vim on Windows.