### PR TITLE
Fix Neovim head installation fails on macOS

### DIFF
--- a/src/installer/macos_neovim_releases_installer.ts
+++ b/src/installer/macos_neovim_releases_installer.ts
@@ -1,5 +1,6 @@
 import {NeovimReleasesInstaller} from "./neovim_releases_installer";
 
 export class MacosNeovimReleasesInstaller extends NeovimReleasesInstaller {
-  readonly assetNamePatterns: RegExp[] = [/^nvim-macos\.tar\.gz$/];
+  readonly arch = process.arch === "arm64" ? "arm64" : "x86_64";
+  readonly assetNamePatterns: RegExp[] = [RegExp(String.raw`^nvim-macos(?:-${this.arch})?\.tar\.gz$`)];
 }


### PR DESCRIPTION

<!--
If you fixing a bug already reported, use "Issue resolving" template instead.
-->

<!-- Please describe all sections -->

### Describe the bug
<!-- A clear and concise description of what the bug is. -->
This action fails to download and setup Neovim head binary on macOS.

### How to reproduce the problem

Use this action with
- `vim_type`: neovim
- `vim_version`: head
- `download`: available

on macOS runner.

### Expected behavior

Do not fail to setup Neovim.

### Actual behavior
<!-- A clear and concise description of what actual happened. -->
Setup Neovim successfully.

### Screenshots (If possible)


### Additional context (If any)

Neovim provided its binary for macOS as one binary named "nvim-macos.tar.gz" before, but now Neovim provides two binaries, "nvim-macos-x86_64.tar.gz" and "nvim-macos-arm64.tar.gz", for macOS.  The formar is for the Intel mac and the latter is for Apple silicon mac.
Ref: https://github.com/neovim/neovim/commit/036f86feaccb25d8552c4bf4d216f7f2a9205325

This change causes the setup failure of Neovim head binary on macOS runner.
